### PR TITLE
Fix: Handle empty strings when parsing batch reward file

### DIFF
--- a/src/main/java/top/jsls9/oajsfx/service/impl/UserServiceImpl.java
+++ b/src/main/java/top/jsls9/oajsfx/service/impl/UserServiceImpl.java
@@ -385,7 +385,10 @@ public class UserServiceImpl implements UserService {
         }
         switch (cell.getCellType()) {
             case STRING:
-                return Integer.parseInt(cell.getStringCellValue());
+                if(StringUtils.isNotBlank(cell.getStringCellValue())){
+                    return Integer.parseInt(cell.getStringCellValue());
+                }
+                return null;
             case NUMERIC:
                 return (int) cell.getNumericCellValue();
             default:


### PR DESCRIPTION
The batch reward API was failing with a NumberFormatException when the uploaded Excel file contained empty cells in the reward amount column.

This was caused by an attempt to parse an empty string into an Integer. This change adds a check to ensure the string is not blank before parsing, preventing the exception and allowing the process to handle empty cells gracefully.